### PR TITLE
Add file name display on stream page

### DIFF
--- a/bot/server/main.py
+++ b/bot/server/main.py
@@ -80,4 +80,15 @@ async def transmit_file(file_id):
 @bp.route('/stream/<int:file_id>')
 async def stream_file(file_id):
     code = request.args.get('code') or abort(401)
-    return await render_template('player.html', mediaLink=f'{Server.BASE_URL}/dl/{file_id}?code={code}')
+    file = await get_message(file_id) or abort(404)
+
+    if code != file.caption.split('/')[0]:
+        abort(403)
+
+    file_name, _, _ = get_file_properties(file)
+
+    return await render_template(
+        'player.html',
+        mediaLink=f'{Server.BASE_URL}/dl/{file_id}?code={code}',
+        fileName=file_name,
+    )

--- a/bot/server/templates/player.html
+++ b/bot/server/templates/player.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-Frame-Options" content="deny" />
-    <title>ʟᴜᴍɪɴᴏ ⇗ ˣᵖ</title>
+    <title>{{ fileName }} - ʟᴜᴍɪɴᴏ ⇗ ˣᵖ</title>
 
     <link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Orbitron:wght@500&display=swap" rel="stylesheet">
@@ -71,6 +71,13 @@
       .nav-buttons a:hover {
         filter: brightness(1.1);
         transform: translateY(-2px);
+      }
+
+      .file-name {
+        margin: 0.5rem 0;
+        font-size: 1rem;
+        text-align: center;
+        font-weight: 600;
       }
 
       main {
@@ -194,6 +201,7 @@
     </div>
 
     <main>
+      <h2 class="file-name">{{ fileName }}</h2>
       <div class="video-container">
         <video id="stream-media" controls autoplay muted controlsList="nodownload" preload="auto">
           <source src="{{ mediaLink }}" type="video/mp4">


### PR DESCRIPTION
## Summary
- show file name on the video stream web page
- validate code in stream endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6879003e2afc83319e4eae250bcb99d0