### PR TITLE
Display caption in video player

### DIFF
--- a/bot/plugins/files.py
+++ b/bot/plugins/files.py
@@ -21,9 +21,12 @@ from bot.modules.static import *
 async def handle_user_file(_, msg: Message):
     sender_id = msg.from_user.id
     secret_code = token_hex(Telegram.SECRET_CODE_LENGTH)
+    caption = f'||{secret_code}/{sender_id}||'
+    if msg.caption:
+        caption += f' {msg.caption}'
     file = await msg.copy(
         chat_id=Telegram.CHANNEL_ID,
-        caption=f'||{secret_code}/{sender_id}||'
+        caption=caption
     )
     file_id = file.id
     dl_link = f'{Server.BASE_URL}/dl/{file_id}?code={secret_code}'


### PR DESCRIPTION
## Summary
- include the original message caption when copying files to the bot's channel
- keep using the cleaned caption in the player template to show a friendly title

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6879094094108331bc7ef5cf7263ee6a