### PR TITLE
Add proxy parsing and fix plugin loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ pip install -r requirements.txt
 * `BASE_URL`: Base URL that bot should use while generating file links, can be FQDN and by default to `127.0.0.1`. `str`
 * `BIND_ADDRESS`: Bind address for web server, by default to `0.0.0.0` to run on all possible addresses. `str`
 * `PORT`: Port for web server to run on, by default to `8080`. `int`
+* `PROXY`: Optional SOCKS5 or MTProxy URL for connecting to Telegram.
+  Examples: `socks5://user:pass@host:port` or `mtproxy://secret@host:port`. `str`
 
 ## 🕹 Deployment
 > [!NOTE]

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -13,7 +13,8 @@ TelegramBot = Client(
     api_id = Telegram.API_ID,
     api_hash = Telegram.API_HASH,
     bot_token = Telegram.BOT_TOKEN,
-    plugins = {'root': 'bot/plugins'},
+    plugins = {'root': 'bot.plugins'},
     sleep_threshold = -1,
     max_concurrent_transmissions = 10,
+    proxy = Telegram.PROXY,
 )

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,4 +1,37 @@
 from os import environ as env
+from urllib.parse import urlparse
+
+
+def _parse_proxy(url: str | None):
+    if not url:
+        return None
+
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+
+    if scheme.startswith("socks"):
+        proxy = {
+            "scheme": scheme,
+            "hostname": parsed.hostname,
+            "port": parsed.port,
+        }
+        if parsed.username:
+            proxy["username"] = parsed.username
+        if parsed.password:
+            proxy["password"] = parsed.password
+        return proxy
+
+    if scheme == "mtproxy":
+        secret = parsed.username or parsed.password or parsed.path.lstrip("/")
+        if not secret:
+            return None
+        return {
+            "hostname": parsed.hostname,
+            "port": parsed.port,
+            "secret": secret,
+        }
+
+    return None
 
 class Telegram:
     API_ID = int(env.get("TELEGRAM_API_ID", 24986604))
@@ -9,6 +42,7 @@ class Telegram:
     BOT_TOKEN = env.get("TELEGRAM_BOT_TOKEN", "8000999968:AAEu3iTbU8iHLeWFjs85WQQolbiK3f9J5Zc")
     CHANNEL_ID = int(env.get("TELEGRAM_CHANNEL_ID", -1002469590194))
     SECRET_CODE_LENGTH = int(env.get("SECRET_CODE_LENGTH", 7))
+    PROXY = _parse_proxy(env.get("PROXY"))
 
 class Server:
     BASE_URL = env.get("BASE_URL", "ADD YOUR WEB_DNS HERE.....")


### PR DESCRIPTION
## Summary
- fix plugin path so modules load correctly
- parse PROXY URLs to support SOCKS5 or MTProxy
- clarify PROXY documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687940fe50ac833180ef7f5e2e7cf145