### PR TITLE
Fix plugin load and circular dependency

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,6 +1,7 @@
 from bot import TelegramBot
-from bot.server import server
+from bot.server import server, init_app
 
 if __name__ == '__main__':
+    init_app()
     TelegramBot.loop.create_task(server.serve())
     TelegramBot.run()

--- a/bot/config.py
+++ b/bot/config.py
@@ -34,18 +34,18 @@ def _parse_proxy(url: str | None):
     return None
 
 class Telegram:
-    API_ID = int(env.get("TELEGRAM_API_ID", 24986604))
-    API_HASH = env.get("TELEGRAM_API_HASH", "afda6f8e5493b9a5bc87656974f3c82e")
-    OWNER_ID = int(env.get("OWNER_ID", 7875474866))
-    ALLOWED_USER_IDS = env.get("ALLOWED_USER_IDS", "7875474866").split()
-    BOT_USERNAME = env.get("TELEGRAM_BOT_USERNAME", "vdp_v1_bot")
-    BOT_TOKEN = env.get("TELEGRAM_BOT_TOKEN", "8000999968:AAEu3iTbU8iHLeWFjs85WQQolbiK3f9J5Zc")
-    CHANNEL_ID = int(env.get("TELEGRAM_CHANNEL_ID", -1002469590194))
-    SECRET_CODE_LENGTH = int(env.get("SECRET_CODE_LENGTH", 7))
-    PROXY = _parse_proxy(env.get("PROXY"))
+        API_ID = int(env.get("TELEGRAM_API_ID", 24986604))
+        API_HASH = env.get("TELEGRAM_API_HASH", "afda6f8e5493b9a5bc87656974f3c82e")
+        OWNER_ID = int(env.get("OWNER_ID", 7875474866))
+        ALLOWED_USER_IDS = env.get("ALLOWED_USER_IDS", "7875474866").split()
+        BOT_USERNAME = env.get("TELEGRAM_BOT_USERNAME", "vdp_v1_backup_bot")
+        BOT_TOKEN = env.get("TELEGRAM_BOT_TOKEN", "7820281272:AAE0hX7ycUOnlVXQWKMCbToudNb4OwNE1mo")
+        CHANNEL_ID = int(env.get("TELEGRAM_CHANNEL_ID", -1002469590194))
+        SECRET_CODE_LENGTH = int(env.get("SECRET_CODE_LENGTH", 7))
+        PROXY = _parse_proxy(env.get("PROXY"))
 
 class Server:
-    BASE_URL = env.get("BASE_URL", "ADD YOUR WEB_DNS HERE.....")
+    BASE_URL = env.get("BASE_URL", "https://8080-newylbot-fsbpysitestrea-5iup96pue9t.ws-us120.gitpod.io")
     BIND_ADDRESS = env.get("BIND_ADDRESS", "0.0.0.0")
     PORT = int(env.get("PORT", 8080))
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -45,7 +45,7 @@ class Telegram:
         PROXY = _parse_proxy(env.get("PROXY"))
 
 class Server:
-    BASE_URL = env.get("BASE_URL", "https://8080-newylbot-fsbpysitestrea-5iup96pue9t.ws-us120.gitpod.io")
+    BASE_URL = env.get("BASE_URL", "http://")
     BIND_ADDRESS = env.get("BIND_ADDRESS", "0.0.0.0")
     PORT = int(env.get("PORT", 8080))
 

--- a/bot/server/__init__.py
+++ b/bot/server/__init__.py
@@ -2,7 +2,19 @@ from quart import Quart
 from uvicorn import Server as UvicornServer, Config
 from logging import getLogger
 from bot.config import Server, LOGGER_CONFIG_JSON
-from . import main, error
+
+def init_app():
+    """Initialize routes and error handlers."""
+    from . import main, error  # Local import to avoid circular dependency
+
+    instance.register_blueprint(main.bp)
+
+    instance.register_error_handler(400, error.invalid_request)
+    instance.register_error_handler(404, error.not_found)
+    instance.register_error_handler(405, error.invalid_method)
+    instance.register_error_handler(error.HTTPError, error.http_error)
+
+    return instance
 
 logger = getLogger('uvicorn')
 instance = Quart(__name__)
@@ -14,12 +26,6 @@ async def before_serve():
     logger.info('Web server is started!')
     logger.info(f'Server running on {Server.BIND_ADDRESS}:{Server.PORT}')
 
-instance.register_blueprint(main.bp)
-
-instance.register_error_handler(400, error.invalid_request)
-instance.register_error_handler(404, error.not_found)
-instance.register_error_handler(405, error.invalid_method)
-instance.register_error_handler(error.HTTPError, error.http_error)
 
 server = UvicornServer (
     Config (


### PR DESCRIPTION
## Summary
- avoid circular import when loading HTTP server
- add init_app() and call it before serving
- make plugin directory a package

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m bot` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6880b059fdac832e92d495a9ea212ac9