### PR TITLE
Rewrite config to clear indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ pip install -r requirements.txt
 * `BASE_URL`: Base URL that bot should use while generating file links, can be FQDN and by default to `127.0.0.1`. `str`
 * `BIND_ADDRESS`: Bind address for web server, by default to `0.0.0.0` to run on all possible addresses. `str`
 * `PORT`: Port for web server to run on, by default to `8080`. `int`
+* `PROXY_TYPE`: Proxy scheme such as `socks5` or `http`. Optional. `str`
+* `PROXY_HOST`: Hostname or IP address of the proxy server. Optional. `str`
+* `PROXY_PORT`: Port of the proxy server. Optional. `int`
+* `PROXY_USERNAME`: Username for the proxy server if required. Optional. `str`
+* `PROXY_PASSWORD`: Password for the proxy server if required. Optional. `str`
 
 ## 🕹 Deployment
 > [!NOTE]

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,7 +1,7 @@
 from hydrogram import Client
 from logging import getLogger
 from logging.config import dictConfig
-from .config import Telegram, LOGGER_CONFIG_JSON
+from .config import Telegram, Server, LOGGER_CONFIG_JSON
 
 dictConfig(LOGGER_CONFIG_JSON)
 
@@ -13,6 +13,7 @@ TelegramBot = Client(
     api_id = Telegram.API_ID,
     api_hash = Telegram.API_HASH,
     bot_token = Telegram.BOT_TOKEN,
+    proxy = getattr(Server, "PROXY", None),
     plugins = {'root': 'bot/plugins'},
     sleep_threshold = -1,
     max_concurrent_transmissions = 10,

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,5 +1,6 @@
 from os import environ as env
 
+
 class Telegram:
     API_ID = int(env.get("TELEGRAM_API_ID", 24986604))
     API_HASH = env.get("TELEGRAM_API_HASH", "afda6f8e5493b9a5bc87656974f3c82e")
@@ -10,47 +11,69 @@ class Telegram:
     CHANNEL_ID = int(env.get("TELEGRAM_CHANNEL_ID", -1002469590194))
     SECRET_CODE_LENGTH = int(env.get("SECRET_CODE_LENGTH", 7))
 
+
 class Server:
     BASE_URL = env.get("BASE_URL", "ADD YOUR WEB_DNS HERE.....")
     BIND_ADDRESS = env.get("BIND_ADDRESS", "0.0.0.0")
     PORT = int(env.get("PORT", 8080))
 
+    PROXY_TYPE = env.get("PROXY_TYPE")
+    PROXY_HOST = env.get("PROXY_HOST")
+    PROXY_PORT = env.get("PROXY_PORT")
+    PROXY_USERNAME = env.get("PROXY_USERNAME")
+    PROXY_PASSWORD = env.get("PROXY_PASSWORD")
+
+    if PROXY_TYPE and PROXY_HOST and PROXY_PORT:
+        PROXY = {
+            "scheme": PROXY_TYPE,
+            "hostname": PROXY_HOST,
+            "port": int(PROXY_PORT),
+        }
+
+        if PROXY_USERNAME:
+            PROXY["username"] = PROXY_USERNAME
+        if PROXY_PASSWORD:
+            PROXY["password"] = PROXY_PASSWORD
+    else:
+        PROXY = None
+
+
 # LOGGING CONFIGURATION
 LOGGER_CONFIG_JSON = {
-    'version': 1,
-    'formatters': {
-        'default': {
-            'format': '[%(asctime)s][%(name)s][%(levelname)s] -> %(message)s',
-            'datefmt': '%d/%m/%Y %H:%M:%S'
-        },
-    },
-    'handlers': {
-        'file_handler': {
-            'class': 'logging.FileHandler',
-            'filename': 'event-log.txt',
-            'formatter': 'default'
-        },
-        'stream_handler': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'default'
+    "version": 1,
+    "formatters": {
+        "default": {
+            "format": "[%(asctime)s][%(name)s][%(levelname)s] -> %(message)s",
+            "datefmt": "%d/%m/%Y %H:%M:%S",
         }
     },
-    'loggers': {
-        'uvicorn': {
-            'level': 'INFO',
-            'handlers': ['file_handler', 'stream_handler']
+    "handlers": {
+        "file_handler": {
+            "class": "logging.FileHandler",
+            "filename": "event-log.txt",
+            "formatter": "default",
         },
-        'uvicorn.error': {
-            'level': 'WARNING',
-            'handlers': ['file_handler', 'stream_handler']
+        "stream_handler": {
+            "class": "logging.StreamHandler",
+            "formatter": "default",
         },
-        'bot': {
-            'level': 'INFO',
-            'handlers': ['file_handler', 'stream_handler']
+    },
+    "loggers": {
+        "uvicorn": {
+            "level": "INFO",
+            "handlers": ["file_handler", "stream_handler"],
         },
-        'hydrogram': {
-            'level': 'INFO',
-            'handlers': ['file_handler', 'stream_handler']
-        }
-    }
+        "uvicorn.error": {
+            "level": "WARNING",
+            "handlers": ["file_handler", "stream_handler"],
+        },
+        "bot": {
+            "level": "INFO",
+            "handlers": ["file_handler", "stream_handler"],
+        },
+        "hydrogram": {
+            "level": "INFO",
+            "handlers": ["file_handler", "stream_handler"],
+        },
+    },
 }


### PR DESCRIPTION
## Summary
- rewrite `bot/config.py` from scratch to ensure no stray whitespace
- support optional proxy config and document env variables
- make proxy attribute optional when starting the bot

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6880ab3cf588832e814c1e953a6381c8