### PR TITLE
Improve caption parsing

### DIFF
--- a/bot/modules/telegram.py
+++ b/bot/modules/telegram.py
@@ -53,3 +53,19 @@ def get_file_properties(msg: Message):
     mime_type = guess_type(file_name)[0] or 'application/octet-stream'
 
     return file_name, file_size, mime_type
+
+
+def parse_caption_meta(caption: str) -> tuple[str, int]:
+    """Return the secret code and user ID embedded in a caption."""
+
+    text = caption.strip()
+
+    if text.startswith("||") and "||" in text[2:]:
+        text = text[2:].split("||", 1)[0]
+    elif text.startswith("`") and "`" in text[1:]:
+        text = text[1:].split("`", 1)[0]
+
+    code, user_part = text.split('/', 1)
+    user_id = int(user_part.split('||')[0].split()[0])
+
+    return code.strip('|'), user_id

--- a/bot/plugins/callback.py
+++ b/bot/plugins/callback.py
@@ -2,7 +2,7 @@ from hydrogram.types import CallbackQuery
 from bot import TelegramBot
 from bot.modules.decorators import verify_user
 from bot.modules.static import *
-from bot.modules.telegram import get_message
+from bot.modules.telegram import get_message, parse_caption_meta
 
 @TelegramBot.on_callback_query()
 @verify_user
@@ -10,19 +10,19 @@ async def manage_callback(bot, q: CallbackQuery):
     query = q.data
 
     if query.startswith('rm_'):
-        sq = query.split('_')
+        parts = query.split('_')
 
-        if len(sq) != 3:
+        if len(parts) != 3:
             return await q.answer(InvalidQueryText, show_alert=True)
 
-        message = await get_message(int(sq[1]))
+        message = await get_message(int(parts[1]))
 
         if not message:
             return await q.answer(MessageNotExist, show_alert=True)
         
-        sc = message.caption.split('/')
+        stored_code, user_id = parse_caption_meta(message.caption)
 
-        if q.from_user.id != int(sc[1]) or sq[2] != sc[0]:
+        if q.from_user.id != user_id or parts[2] != stored_code:
             return await q.answer(InvalidQueryText, show_alert=True)
         
         await message.delete()


### PR DESCRIPTION
## Summary
- add `parse_caption_meta` helper to handle spoiler and code formatting
- use new helper in callback handler
- reuse helper when verifying codes in the server

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6880aaba923c832e9c9c85522fd0ad95